### PR TITLE
Make the datgui element a sibling of the meshcat-pane, not a child

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -735,7 +735,7 @@ class Viewer {
         this.gui = new dat.GUI({
             autoPlace: false
         });
-        this.dom_element.appendChild(this.gui.domElement);
+        this.dom_element.parentElement.appendChild(this.gui.domElement);
         this.gui.domElement.style.position = "absolute";
         this.gui.domElement.style.right = 0;
         this.gui.domElement.style.top = 0;


### PR DESCRIPTION
Sets the DOM element of the DAT.gui as a child of the _parent_ of the meshcat pane, not a child of the meshcat pane itself.

This solves the issue that the camera orbit controls get triggered when playing with the gui controls. For example, when draggin a slider in the gui controls to change an integer parameter (not currently available in base meschat, though), the camera would also move, which might be annoying.

This works because the orbit controls are initialized by passing the meshcat-pane DOM element, thus they work only for that element (and the children).

I do not see any visual consequence of this change, so it looks good to me. But people with better knowledge of the code base might know of some cons.