### PR TITLE
Allow to set properties recursively

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -407,7 +407,11 @@ class SceneNode {
         } else if (property == "top_color" || property == "bottom_color") {
             this.object[property] = value.map((x) => x * 255);
         } else {
-            this.object[property] = value;
+            let v = this.object;
+            for (const p in property.split('.')) {
+                v = v[p];
+            }
+            v = value;
         }
         this.vis_controller.updateDisplay();
         this.controllers.forEach(c => c.updateDisplay());


### PR DESCRIPTION
This change allows modification of properties of the member instances of the object. For example, it allows to set the green channel of the color through python code:
`vis['obj1']['<object>'].set_property('material.color.g', 1)`
The string is unwrapped into: 
`this.object['material']['color']['g'] = 1`

It also allows animating color transitions with (again from python):
```
frame1['obj1']['<object>'].set_property('material.color', 'vector', [1, 0, 0])
frame2['obj1']['<object>'].set_property('material.color', 'vector', [0, 1, 0])
```
